### PR TITLE
Install oedisi in docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,6 +20,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install -r docs/requirements.txt
+        pip install .
         cd docs
         make html
     - name: Deploy


### PR DESCRIPTION
I noticed in #39 that the docs build wasn't including oedisi indexes since it wasn't installed. This should fix the problem.